### PR TITLE
Fix event bubbling question

### DIFF
--- a/src/data/quiz-data.js
+++ b/src/data/quiz-data.js
@@ -122,9 +122,9 @@ export const questions = [
 	{
 		"question": "What is event bubbling?",
 		"answers": [
-			"When the browser engine goes down the DOM tree looking for events.",
-			"When the browser engine goes up the DOM tree looking for events.",
-			"When the browser engine goes sideways on sibling elements looking for events.",
+			"When the browser engine searches down the DOM tree for event handlers.",
+			"When the browser engine searches up the DOM tree for event handlers.",
+			"When the browser engine searches sideways on sibling elements for event handlers.",
 			"None of the above."
 		],
 		"correct": 1


### PR DESCRIPTION
When an event is fired, the browser engine looks for an event handler attached to the element that triggered the event, and then bubbles up the tree giving parent elements a chance to handle the event. Propagation can be canceled during any event handler in the tree.

Event propagation is not "looking for events" -- it's looking for handlers to handle the event that was originally triggered.